### PR TITLE
Use proper capitalization for the GitHub brand

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
               <a class="nav-link" href="#Gitter">Gitter</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#Github">Github</a>
+              <a class="nav-link" href="#GitHub">GitHub</a>
             </li>
           </ul>
         </div>
@@ -77,12 +77,12 @@
         <h1 class="display-5 righteous">About Us</h1>
         <hr/>
         <h5>
-          We are a group of programmers helping each other out to build new things, whether it be writing
+          We are a group of programmers helping each other to build new things, whether it be writing
           complex encryption programs, or simple ciphers. Our goal is to work together to document and
           model beautiful, helpful and interesting algorithms using code. We are an open-source community -
-          anyone can contribute. We check each other's work, communicate and work together to solve
+          anyone can contribute. We check each other's work, communicate and collaborate to solve
           problems. We strive to be welcoming, respectful, yet make sure that our code follows the latest
-          guidelines.
+          programming guidelines.
         </h5>
       </div>
     </div>
@@ -94,8 +94,8 @@
           An algorithm is a set of rules that takes in one or more inputs, then performs inner calculations
           and data manipulations and returns an output or a set of outputs. In short, algorithms make life
           easy. From complex data manipulations and hashes, to simple arithmetic, algorithms follow
-          a set of steps to give a result. One example of an algorithm would be a simple function that takes
-          in two values, adds them together and returns the sum.
+          a set of steps to produce a usefulresult. One example of an algorithm would be a simple function
+          that takes two input values, adds them together and returns their sum.
         </h5>
       </div>
     </div>
@@ -104,7 +104,7 @@
       <div class="container py-5">
         <h1 class="display-5 righteous">Programming Languages</h1>
         <h5>
-          We support many programming languages. Each language has its own github repository where all the
+          We support many programming languages. Each language has its own GitHub repository where all the
           code for the algorithms is stored. Here is a list of the current programming languages:
         </h5>
         <h2 class="pt-5">
@@ -121,7 +121,7 @@
           <div class="grid-item"><a target="_blank" href="https://github.com/TheAlgorithms/R"><img src="./images/svg/r-lang.svg" height="50px" alt="R Logo"/><br><span class="language-name">R</span></a></div>
           <div class="grid-item"><a target="_blank" href="https://github.com/TheAlgorithms/Ruby"><img src="./images/svg/ruby.svg" height="50px" alt="Ruby Logo"/><br><span class="language-name">Ruby</span></a></div>
           <div class="grid-item"><a target="_blank" href="https://github.com/TheAlgorithms/MATLAB-Octave"><img src="./images/svg/matlab.png" height="50px" alt="MATLAB/Octave Logo"/><br><span class="language-name">MATLAB/<br>Octave</span></a></div>
-		  <div class="grid-item"><a target="_blank" href="https://github.com/TheAlgorithms/Dart"><img src="./images/svg/dart.png" height="50px" alt="Dart Logo"/><br><span class="language-name">Dart</span></a></div>
+          <div class="grid-item"><a target="_blank" href="https://github.com/TheAlgorithms/Dart"><img src="./images/svg/dart.png" height="50px" alt="Dart Logo"/><br><span class="language-name">Dart</span></a></div>
         </div>
         </h2>
       </div>
@@ -131,23 +131,23 @@
       <div class="container py-5 text-white">
         <h1 class="display-5 righteous">Contribute</h1>
         <h5>
-          We love when people contribute to the repositories. If you have an algorithm
-          that you want to add, a change you want to address or a bug fix, please do
-          so. But before you do, <strong>make sure you have read the contributing
-            guidelines found in CONTRIBUTING.md in the repository.</strong> Make sure
+          We encourage you to contribute to these repositories. If you have an algorithm
+          that you want to add, a change you want to make or a bug you want to fix, please
+	        do so. But before you do, <strong>make sure you have read the contributing
+          guidelines found in CONTRIBUTING.md in the repository.</strong> Make sure
           that you are respectful, helpful and using the latest version of the language.
-          After reading the contribution guidelines, you can fork
-          the repository, work on changes and then submit a pull request.
+          After reading the contribution guidelines, please fork the repository, work on
+          your changes and then submit them as a pull request.
         </h5>
 
       </div>
     </div>
 
-    <div id="Github" class="bg-light">
+    <div id="GitHub" class="bg-light">
       <div class="container py-5">
         <h1 class="display-5 righteous">Github</h1>
         <h5><a class="text-dark" href="https://github.com/TheAlgorithms/"><u>TheAlgorithms
-              organization is found in github.</u></h5> Here you can find all the repositories
+              organization is found in GitHub.</u></h5> Here you can find all the repositories
         as well as see organization members and contact info.
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
         <h5>
           We encourage you to contribute to these repositories. If you have an algorithm
           that you want to add, a change you want to make or a bug you want to fix, please
-	        do so. But before you do, <strong>make sure you have read the contributing
+          do so. But before you do, <strong>make sure you have read the contributing
           guidelines found in CONTRIBUTING.md in the repository.</strong> Make sure
           that you are respectful, helpful and using the latest version of the language.
           After reading the contribution guidelines, please fork the repository, work on

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
           An algorithm is a set of rules that takes in one or more inputs, then performs inner calculations
           and data manipulations and returns an output or a set of outputs. In short, algorithms make life
           easy. From complex data manipulations and hashes, to simple arithmetic, algorithms follow
-          a set of steps to produce a usefulresult. One example of an algorithm would be a simple function
+          a set of steps to produce a useful result. One example of an algorithm would be a simple function
           that takes two input values, adds them together and returns their sum.
         </h5>
       </div>


### PR DESCRIPTION
We are still missing the Jupyter logo.