### PR TITLE
Removed duplicate GitHub section

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,15 +147,6 @@
       <div class="container py-5">
         <h1 class="display-5 righteous">GitHub</h1>
         <h5><a class="text-dark" href="https://github.com/TheAlgorithms/"><u>TheAlgorithms
-              organization is found in GitHub.</u></h5> Here you can find all the repositories
-        as well as see organization members and contact info.
-      </div>
-    </div>
-
-    <div id="GitHub" class="bg-light">
-      <div class="container py-5">
-        <h1 class="display-5 righteous">GitHub</h1>
-        <h5><a class="text-dark" href="https://github.com/TheAlgorithms/"><u>TheAlgorithms
               organization is found in GitHub.</u></a></h5> Here you can find all the repositories
         as well as see organization members and contact info.
       </div>


### PR DESCRIPTION
![Screenshot_2020-06-09 Welcome to TheAlgorithms](https://user-images.githubusercontent.com/49735721/84177715-df5cf580-aa48-11ea-8dd1-a810f27143fd.png)

The GitHub section of the site had a duplicate of itself right under the original. This was probably caused by maintainers wanting to add improvements to the section but accidentally ending up copying it. I removed the duplicate section.


