### PR TITLE
Fixed broken Gitter link

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
               <a class="nav-link" href="#Contribute">Contribute</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="#Gitter">Gitter</a>
+              <a class="nav-link" href="https://gitter.im/TheAlgorithms/">Gitter</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#GitHub">GitHub</a>


### PR DESCRIPTION
Fixed broken Gitter link, by changing the `href` to TheAlgorithms gitter page.

Fixes #20 