### PR TITLE
Fixed overflow of grid items

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -32,6 +32,7 @@ div.grid {
   text-align: center;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
+  overflow-x: scroll;
 }
 
 div.grid-item {


### PR DESCRIPTION
I have visited this site on my device, and I've noticed the overflow of some contents; fixed the issue by adding a overflow-x property in css file to enable horizontal scrolling of grid items, thus grid items won't break the layout.

This is how it looks on my device:
![Screenshot_2021-02-01-23-05-08-82](https://user-images.githubusercontent.com/46290852/106501544-4ef88700-64e9-11eb-8ef4-c7c579c23533.jpg)
